### PR TITLE
Patch 2.0.27 using the instructions in the README

### DIFF
--- a/patches/2.0.27/metadata.json
+++ b/patches/2.0.27/metadata.json
@@ -1,0 +1,43 @@
+{
+  "version": "2.0.27",
+  "recordedAt": "2025-10-25T02:26:14.008Z",
+  "sandbox": "sandboxes/2.0.27",
+  "replacementsSource": "2.0.27",
+  "replacements": "patches/2.0.27/replacements.json",
+  "patchState": {
+    "version": "2.0.27",
+    "replacementsSource": "2.0.27",
+    "replacements": [
+      {
+        "label": "killBufferRef insertion",
+        "search": "} = O7(), P = jy(",
+        "replace": "} = O7(), killBufferRef = Jy1.useRef(\"\"), recordKill = DA1 => { if (DA1 && DA1.length > 0) killBufferRef.current = DA1; }, P = jy("
+      },
+      {
+        "label": "recordKill in reset helper",
+        "search": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        return O5.fromText(\"\", V, 0);\n    }",
+        "replace": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        recordKill(O.text);\n        return O5.fromText(\"\", V, 0);\n    }"
+      },
+      {
+        "label": "Ctrl+K kill ring",
+        "search": "[ \"k\", () => O.deleteToLineEnd() ]",
+        "replace": "[ \"k\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteToLineEnd();\n        recordKill(K1.slice(j1));\n        return W1;\n    } ]"
+      },
+      {
+        "label": "Ctrl+U kill ring",
+        "search": "[ \"u\", () => O.deleteToLineStart() ]",
+        "replace": "[ \"u\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteToLineStart();\n        recordKill(K1.slice(W1.offset, j1));\n        return W1;\n    } ]"
+      },
+      {
+        "label": "Ctrl+W kill ring + yank",
+        "search": "[ \"w\", () => O.deleteWordBefore() ] ]),",
+        "replace": "[ \"w\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteWordBefore();\n        recordKill(K1.slice(W1.offset, j1));\n        return W1;\n    } ], [ \"y\", () => killBufferRef.current ? O.insert(killBufferRef.current) : O ] ]),"
+      },
+      {
+        "label": "Meta+D kill ring",
+        "search": "[ \"d\", () => O.deleteWordAfter() ] ]);",
+        "replace": "[ \"d\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteWordAfter(), z1 = K1.length - W1.text.length;\n        if (z1 > 0) recordKill(K1.slice(j1, j1 + z1));\n        return W1;\n    } ] ]);"
+      }
+    ]
+  }
+}

--- a/patches/2.0.27/replacements.json
+++ b/patches/2.0.27/replacements.json
@@ -1,0 +1,32 @@
+[
+  {
+    "label": "killBufferRef insertion",
+    "search": "} = O7(), P = jy(",
+    "replace": "} = O7(), killBufferRef = Jy1.useRef(\"\"), recordKill = DA1 => { if (DA1 && DA1.length > 0) killBufferRef.current = DA1; }, P = jy("
+  },
+  {
+    "label": "recordKill in reset helper",
+    "search": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        return O5.fromText(\"\", V, 0);\n    }",
+    "replace": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        recordKill(O.text);\n        return O5.fromText(\"\", V, 0);\n    }"
+  },
+  {
+    "label": "Ctrl+K kill ring",
+    "search": "[ \"k\", () => O.deleteToLineEnd() ]",
+    "replace": "[ \"k\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteToLineEnd();\n        recordKill(K1.slice(j1));\n        return W1;\n    } ]"
+  },
+  {
+    "label": "Ctrl+U kill ring",
+    "search": "[ \"u\", () => O.deleteToLineStart() ]",
+    "replace": "[ \"u\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteToLineStart();\n        recordKill(K1.slice(W1.offset, j1));\n        return W1;\n    } ]"
+  },
+  {
+    "label": "Ctrl+W kill ring + yank",
+    "search": "[ \"w\", () => O.deleteWordBefore() ] ]),",
+    "replace": "[ \"w\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteWordBefore();\n        recordKill(K1.slice(W1.offset, j1));\n        return W1;\n    } ], [ \"y\", () => killBufferRef.current ? O.insert(killBufferRef.current) : O ] ]),"
+  },
+  {
+    "label": "Meta+D kill ring",
+    "search": "[ \"d\", () => O.deleteWordAfter() ] ]);",
+    "replace": "[ \"d\", () => {\n        let K1 = O.text, j1 = O.offset, W1 = O.deleteWordAfter(), z1 = K1.length - W1.text.length;\n        if (z1 > 0) recordKill(K1.slice(j1, j1 + z1));\n        return W1;\n    } ] ]);"
+  }
+]


### PR DESCRIPTION
Patches created via claude code using the instructions in this repo.

```diff
diff -u patches/2.0.26/metadata.json patches/2.0.27/metadata.json
--- patches/2.0.26/metadata.json        2025-10-24 22:17:52
+++ patches/2.0.27/metadata.json        2025-10-24 22:26:14
@@ -1,22 +1,22 @@
 {
-  "version": "2.0.26",
+  "version": "2.0.27",
-  "recordedAt": "2025-10-24T03:08:54.098Z",
+  "recordedAt": "2025-10-25T02:26:14.008Z",
-  "sandbox": "sandboxes/2.0.26",
+  "sandbox": "sandboxes/2.0.27",
-  "replacementsSource": "2.0.26",
+  "replacementsSource": "2.0.27",
-  "replacements": "patches/2.0.26/replacements.json",
+  "replacements": "patches/2.0.27/replacements.json",
   "patchState": {
-    "version": "2.0.26",
+    "version": "2.0.27",
-    "replacementsSource": "2.0.26",
+    "replacementsSource": "2.0.27",
     "replacements": [
       {
         "label": "killBufferRef insertion",
-        "search": "} = q7(), j = yy(",
+        "search": "} = O7(), P = jy(",
-        "replace": "} = q7(), killBufferRef = OD.useRef(\"\"), recordKill = DA1 => { if (DA1 && DA1.length > 0) killBufferRef.current = DA1; }, j = yy("
+        "replace": "} = O7(), killBufferRef = Jy1.useRef(\"\"), recordKill = DA1 => { if (DA1 && DA1.length > 0) killBufferRef.current = DA1; }, P = jy("
       },
       {
         "label": "recordKill in reset helper",
-        "search": "    function h() {\n        if (A.trim() !== \"\") q_(A), J?.();\n        return M5.fromText(\"\", V, 0);\n    }",
+        "search": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        return O5.fromText(\"\", V, 0);\n    }",
-        "replace": "    function h() {\n        if (A.trim() !== \"\") q_(A), J?.();\n        recordKill(O.text);\n        return M5.fromText(\"\", V, 0);\n    }"
+        "replace": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        recordKill(O.text);\n        return O5.fromText(\"\", V, 0);\n    }"
       },
       {
         "label": "Ctrl+K kill ring",
diff -u patches/2.0.26/replacements.json patches/2.0.27/replacements.json
--- patches/2.0.26/replacements.json    2025-10-24 22:17:52
+++ patches/2.0.27/replacements.json    2025-10-24 22:26:14
@@ -1,13 +1,13 @@
 [
   {
     "label": "killBufferRef insertion",
-    "search": "} = q7(), j = yy(",
+    "search": "} = O7(), P = jy(",
-    "replace": "} = q7(), killBufferRef = OD.useRef(\"\"), recordKill = DA1 => { if (DA1 && DA1.length > 0) killBufferRef.current = DA1; }, j = yy("
+    "replace": "} = O7(), killBufferRef = Jy1.useRef(\"\"), recordKill = DA1 => { if (DA1 && DA1.length > 0) killBufferRef.current = DA1; }, P = jy("
   },
   {
     "label": "recordKill in reset helper",
-    "search": "    function h() {\n        if (A.trim() !== \"\") q_(A), J?.();\n        return M5.fromText(\"\", V, 0);\n    }",
+    "search": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        return O5.fromText(\"\", V, 0);\n    }",
-    "replace": "    function h() {\n        if (A.trim() !== \"\") q_(A), J?.();\n        recordKill(O.text);\n        return M5.fromText(\"\", V, 0);\n    }"
+    "replace": "    function h() {\n        if (A.trim() !== \"\") w_(A), J?.();\n        recordKill(O.text);\n        return O5.fromText(\"\", V, 0);\n    }"
   },
   {
     "label": "Ctrl+K kill ring",
```