### PR TITLE
Support symlinked claude in PATH

### DIFF
--- a/claude
+++ b/claude
@@ -5,7 +5,14 @@
 # launch it via `./claude --version X.Y.Z`. If no version is provided, the
 # newest sandbox under sandboxes/ is used automatically.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks to find the actual script location
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 SANDBOX_ROOT="$SCRIPT_DIR/sandboxes"
 
 usage() {

--- a/patch-claude
+++ b/patch-claude
@@ -5,5 +5,12 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks to find the actual script location
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 exec node "$SCRIPT_DIR/tools/patch-claude.js" "$@"


### PR DESCRIPTION
Usage
-----

1. Clone claude-yank-patcher into any directory, e.g. ~/git/claude-yank-patcher
2. Symlink to a directory in $PATH, e.g. /usr/local/bin/claude -> ~/git/claude-yank-patcher/claude

This seems like a typical installation strategy, which previously was not supported. The scripts now resolve symlinks to find the project directory rather than assuming that the script symlink directory contains the sandboxes.

Without this change, running `claude` would emit this error despite there being sandboxes for the current version.

```
❌ No sandboxes found.
Run: ./patch-claude --version <semver>
```